### PR TITLE
Fix quality mapping

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,5 +4,5 @@
     <setting id="useSubtitles" type="bool" label="30029" default="false" />
     <setting id="useServiceAPI" type="bool" label="30026" default="false" />
     <setting id="enableBlacklist" type="bool" label="30043" default="false" />
-    <setting id="videoQuality" type="enum"  label="30022" lvalues="30044|30025|30024|30023" default="30044"/>
+    <setting id="videoQuality" type="enum"  label="30022" lvalues="30023|30024|30025|30044" default="3"/>
 </settings>


### PR DESCRIPTION
Was introduced in 3a7209c.
If you prefer to keep the order in the setting dialog, I can fix it by changing the quality mapping function (`Settings.videoQuality(...)`).