### PR TITLE
serviceAPI: add restart functionality

### DIFF
--- a/default.py
+++ b/default.py
@@ -225,6 +225,8 @@ elif mode == 'openEpisode':
 elif mode == 'liveStreamNotOnline':
     scraper.getLiveNotOnline(link)
     listCallback(False,pluginhandle)
+elif mode == 'liveStreamRestart':
+    scraper.liveStreamRestart(link)
 elif mode == 'playlist':
     startPlaylist(tvthekplayer,playlist)
 elif sys.argv[2] == '':

--- a/resources/lib/base.py
+++ b/resources/lib/base.py
@@ -19,7 +19,9 @@ def addDirectory(title,banner,backdrop, description,link,mode,pluginhandle):
     u = sys.argv[0] + '?' + urllib.urlencode(parameters)
     createListItem(title,banner,description,'','','',u, False,True, backdrop,pluginhandle,None)
 
-def createListItem(title,banner,description,duration,date,channel,videourl,playable,folder, backdrop,pluginhandle,subtitles=None,blacklist=False):
+def createListItem(title,banner,description,duration,date,channel,videourl,playable,folder, backdrop,pluginhandle,subtitles=None,blacklist=False, contextMenuItems = None):
+    contextMenuItems = contextMenuItems or []
+
     liz=xbmcgui.ListItem(title)
     liz.setIconImage(banner)
     liz.setThumbnailImage(banner)
@@ -74,12 +76,11 @@ def createListItem(title,banner,description,duration,date,channel,videourl,playa
 
         blparameters = {"mode" : "blacklistShow", "title": bl_title}
         blurl = sys.argv[0] + '?' + urllib.urlencode(blparameters)
-        commands = []
-        commands.append(('%s %s %s' % (Settings.localizedString(30038).encode("utf-8"), bl_title, Settings.localizedString(30042).encode("utf-8")), 'XBMC.RunPlugin(%s)' % blurl))
-        liz.addContextMenuItems( commands )
+        contextMenuItems.append(('%s %s %s' % (Settings.localizedString(30038).encode("utf-8"), bl_title, Settings.localizedString(30042).encode("utf-8")), 'XBMC.RunPlugin(%s)' % blurl))
         if checkBlacklist(bl_title):
             return
 
+    liz.addContextMenuItems(contextMenuItems)
     xbmcplugin.addDirectoryItem(pluginhandle, url=videourl, listitem=liz, isFolder=folder)
     return liz
 

--- a/resources/lib/base.py
+++ b/resources/lib/base.py
@@ -77,12 +77,11 @@ def createListItem(title,banner,description,duration,date,channel,videourl,playa
         commands = []
         commands.append(('%s %s %s' % (Settings.localizedString(30038).encode("utf-8"), bl_title, Settings.localizedString(30042).encode("utf-8")), 'XBMC.RunPlugin(%s)' % blurl))
         liz.addContextMenuItems( commands )
-        if not checkBlacklist(bl_title):
-            xbmcplugin.addDirectoryItem(pluginhandle, url=videourl, listitem=liz, isFolder=folder)
-            return liz
-    else:
-        xbmcplugin.addDirectoryItem(pluginhandle, url=videourl, listitem=liz, isFolder=folder)
-        return liz
+        if checkBlacklist(bl_title):
+            return
+
+    xbmcplugin.addDirectoryItem(pluginhandle, url=videourl, listitem=liz, isFolder=folder)
+    return liz
 
 def checkBlacklist(title):
     addonUserDataFolder = xbmc.translatePath("special://profile/addon_data/plugin.video.orftvthek");

--- a/resources/lib/serviceapi.py
+++ b/resources/lib/serviceapi.py
@@ -280,8 +280,11 @@ class serviceAPI(Scraper):
 				livestreamEnd   = time.strptime(result.get('end')[0:19],   '%Y-%m-%dT%H:%M:%S')
 				duration        = max(time.mktime(livestreamEnd) - max(time.mktime(livestreamStart), time.mktime(time.localtime())), 1)
 
+				# already finished
+				if time.mktime(livestreamEnd) < time.mktime(time.localtime()):
+					continue
 				# already playing
-				if livestreamStart < time.localtime():
+				elif livestreamStart < time.localtime():
 					link = self.JSONStreamingURL(result.get('sources')) + '|User-Agent=Mozilla'
 				else:
 					link = sys.argv[0] + '?' + urllib.urlencode({'mode': 'liveStreamNotOnline', 'link': result.get('id')})


### PR DESCRIPTION
The restart functionality only works if `inputstream.adaptive` binary addon is enabled.