### PR TITLE
fixed: don't set directory=true on the "play all" listitem

### DIFF
--- a/default.py
+++ b/default.py
@@ -124,16 +124,13 @@ def startPlaylist(player,playlist):
 #modes
 if mode == 'openSeries':
     playlist.clear()
-    playlist = scraper.getLinks(link,params.get('banner'),playlist)
-    if not autoPlayPrompt:
-        listCallback(False,pluginhandle)
-    elif playlist != None:
+    playlist = scraper.getLinks(link,banner,playlist)
+    listCallback(False,pluginhandle)
+    if autoPlayPrompt and playlist != None:
         ok = xbmcgui.Dialog().yesno((translation(30047)).encode("utf-8"),(translation(30048)).encode("utf-8"))
         if ok:
             debugLog("Starting Playlist for %s" % urllib.unquote(link),'Info')
             tvthekplayer.play(playlist)
-    else:
-        listCallback(False,pluginhandle)
 
 elif mode == 'unblacklistShow':
     heading = translation(30040).encode('UTF-8') % urllib.unquote(link).replace('+', ' ').strip()

--- a/resources/lib/htmlscraper.py
+++ b/resources/lib/htmlscraper.py
@@ -361,7 +361,7 @@ class htmlScraper(Scraper):
                 debugLog("Found Video Playlist with %d Items" % len(video_items),'Info')
                 parameters = {"mode" : "playlist"}
                 u = sys.argv[0] + '?' + urllib.urlencode(parameters)
-                liz = self.html2ListItem("[ "+(self.translation(30015)).encode("utf-8")+" ]",banner,"",(self.translation(30015)).encode("utf-8"),'','','',u, None,True, True);
+                liz = self.html2ListItem("[ "+(self.translation(30015)).encode("utf-8")+" ]",banner,"",(self.translation(30015)).encode("utf-8"),'','','',u,None,False,False);
                 for video_item in video_items:
                     try:
                         title = video_item["title"].encode('UTF-8')
@@ -695,3 +695,4 @@ class htmlScraper(Scraper):
             parameters = {'mode' : 'getSearchHistory'}
             u = sys.argv[0] + '?' + urllib.urlencode(parameters)
             createListItem((self.translation(30014)).encode("utf-8")+" ...", self.defaultbanner, "", "", "", '', u, False, True, self.defaultbackdrop,self.pluginhandle,None)
+


### PR DESCRIPTION
setting directory=True on a playlist causes crashes on Kodi master, due to dialogBusy getting called under the hood.
see https://github.com/xbmc/xbmc/pull/13833 and https://github.com/xbmc/xbmc/pull/13954