### PR TITLE
Add single-source play-all for serviceapi scraper.

### DIFF
--- a/default.py
+++ b/default.py
@@ -67,11 +67,12 @@ useServiceAPI = Settings.serviceAPI()
 videoQuality = Settings.videoQuality(video_quality_list)
 videoDelivery = Settings.videoDelivery(video_delivery_list)
 autoPlayPrompt = Settings.autoPlayPrompt()
+usePlayAllPlaylist = Settings.playAllPlaylist()
 
 #init scrapers
 if useServiceAPI:
     debugLog("Service API activated",'Info')
-    scraper = serviceAPI(xbmc, settings, pluginhandle, videoQuality, videoProtocol, videoDelivery, defaultbanner, defaultbackdrop)
+    scraper = serviceAPI(xbmc, settings, pluginhandle, videoQuality, videoProtocol, videoDelivery, defaultbanner, defaultbackdrop, usePlayAllPlaylist)
 else:
     debugLog("HTML Scraper activated",'Info')
     scraper = htmlScraper(xbmc, settings, pluginhandle, videoQuality, videoProtocol, videoDelivery, defaultbanner, defaultbackdrop)

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -230,3 +230,7 @@ msgstr ""
 msgctxt "#30057"
 msgid "In Focus"
 msgstr ""
+
+msgctxt "#30058"
+msgid "Create a playlist for [Play All]"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -216,3 +216,7 @@ msgstr "Progressive Streaming aktivieren"
 msgctxt "#30057"
 msgid "In Focus"
 msgstr "Im Fokus"
+
+msgctxt "#30058"
+msgid "Create a playlist for [Play All]"
+msgstr "Erstelle eine Playlist für [Alle Beiträge abspielen]"

--- a/resources/lib/Settings.py
+++ b/resources/lib/Settings.py
@@ -38,3 +38,6 @@ def videoDelivery(delivery_list):
 
 def autoPlayPrompt():
 	return __addon__.getSetting("autoPlayPrompt") == "true"
+
+def playAllPlaylist():
+	return __addon__.getSetting('usePlayAllPlaylist') == 'true'

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
     <setting id="enableBlacklist" type="bool" label="30043" default="false" />
     <setting id="useServiceAPI" type="bool" label="30026" default="false" />
     <setting id="videoDeliveryProgressive" label="30056" type="bool" visible="eq(-1,true)" default="false" />
+    <setting id="usePlayAllPlaylist" label="30058" type="bool" visible="eq(-2,true)" default="true" />
     <setting id="videoQuality" type="enum"  label="30022" lvalues="30023|30024|30025|30044|30053" default="3"/>
     <setting id="userAgent" default="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36" visible="false" />
 </settings>


### PR DESCRIPTION
Hi there!
Here's an initial PR for #87.
This is still a WIP, as it hasn't been thoroughly tested yet.
I'll change the title / remove the WIP as soon as the code is clean and tested.
The feature is limited to the Service API scraper, as extracting the uncut video from the HTML page is quite tedious and I expect the API scraper to be more stable.