### PR TITLE
live restart API fix

### DIFF
--- a/resources/lib/Addon.py
+++ b/resources/lib/Addon.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import socket
+import traceback
 import xbmcplugin
+import inputstreamhelper
 
 from resources.lib.ServiceApi import *
 from resources.lib.HtmlScraper import *
@@ -223,11 +225,13 @@ def run():
                     play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
                     play_item.setProperty('inputstream.adaptive.stream_headers', headers)
                     play_item.setProperty('inputstream.adaptive.manifest_type', 'hls')
-                debugLog("Restart Stream Url: %s" % streaming_url)
+                debugLog("Restart Stream Url: %s; play_item: %s" % (streaming_url, play_item))
                 xbmc.Player().play(streaming_url, play_item)
             else:
                 userNotification((translation(30066)).encode("utf-8"))
-        except:
+        except Exception as e:
+            debugLog("Exception: %s" % ( e, ), xbmc.LOGINFO)
+            debugLog("TB: %s" % ( traceback.format_exc(), ), xbmc.LOGINFO)
             userNotification((translation(30067)).encode("utf-8"))
     elif mode == 'playlist':
         startPlaylist(tvthekplayer, playlist)

--- a/resources/lib/Helpers.py
+++ b/resources/lib/Helpers.py
@@ -33,6 +33,8 @@ def build_kodi_url(parameters):
 
 
 def encode_parameters(parameters):
+    parameters = { k: v if v is not None else ""
+                   for k, v in parameters.items() }
     try:
         return urlencode(parameters)
     except:

--- a/resources/lib/ServiceApi.py
+++ b/resources/lib/ServiceApi.py
@@ -37,7 +37,7 @@ class serviceAPI(Scraper):
     serviceAPITrailers = 'page/preview?limit=100'
     serviceAPIHighlights = 'page/startpage'
 
-    httpauth = 'cHNfYW5kcm9pZF92Mzo2YTYzZDRkYTI5YzcyMWQ0YTk4NmZkZDMxZWRjOWU0MQ=='
+    httpauth = 'cHNfYW5kcm9pZF92M19uZXc6MDY1MmU0NjZkMTk5MGQxZmRmNDBkYTA4ZTc5MzNlMDY=='
 
     def __init__(self, xbmc, settings, pluginhandle, quality, protocol, delivery, defaultbanner, defaultbackdrop, usePlayAllPlaylist):
         self.translation = settings.getLocalizedString

--- a/resources/lib/ServiceApi.py
+++ b/resources/lib/ServiceApi.py
@@ -4,6 +4,7 @@
 import datetime
 import time
 import sys
+import re
 
 PY3 = sys.version_info.major >=3
 if PY3:
@@ -369,14 +370,26 @@ class serviceAPI(Scraper):
             description = result.get('description')
             duration = result.get('duration_seconds')
             date = time.strptime(result.get('start')[0:19], '%Y-%m-%dT%H:%M:%S')
-
-            ApiKey = '2e9f11608ede41f1826488f1e23c4a8d'
-            debugLog("Restart Url: %s" % result.get('channel_restart_url_android'))
-            bitmovinStreamId = result.get('channel_restart_url_android')
-            if bitmovinStreamId:
-                bitmovinStreamId = bitmovinStreamId.replace("https://playerapi-restarttv.ors.at/livestreams/", "").replace("/sections/", "")
-                bitmovinStreamId = bitmovinStreamId.split("?")[0]
-            response = url_get_request('https://playerapi-restarttv.ors.at/livestreams/%s/sections/?state=active&X-Api-Key=%s' % (bitmovinStreamId, ApiKey))  # nosec
+            restart_urls = None
+            restart_url = None
+            try:
+                restart_urls = result['_embedded']['channel']['restart_urls']
+            except AttributeError:
+                pass
+            else:
+                for x in ('android', 'default'):
+                    if x in restart_urls:
+                        restart_url = restart_urls[x]
+                        if restart_url:
+                            break
+            if not restart_url:
+                raise Exception("restart url not found in livestream/%s result" % (link, ))
+            m = re.search(r"/livestreams/([^/]+)/sections/[^\?]*\?(?:.+&|)?X-Api-Key=([^&]+)", restart_url)
+            if m:
+                bitmovinStreamId, ApiKey = m.groups()
+            else:
+                raise Exception("unable to parse restart url: %s" % ( restart_url, ))
+            response = url_get_request(restart_url)  # nosec
             response_raw = response.read().decode('UTF-8')
             section = json.loads(response_raw)[0]
             section_id = section.get('id')


### PR DESCRIPTION
The JSON result of the  `livestreams` service api call seems to have changed.
The restart url cannot be obtained via `channel_restart_url_android` anymore.
Several restart urls are now present at `_embedded/channel/restart_urls`.