### PR TITLE
Use 50fps UHD manifest instead of 25fps

### DIFF
--- a/resources/lib/ServiceApi.py
+++ b/resources/lib/ServiceApi.py
@@ -344,7 +344,7 @@ class serviceAPI(Scraper):
                     banner = self.JSONImage(result.get('_embedded').get('image'))
 
                     for stream in result.get('sources').get('dash'):
-                        if stream.get('is_uhd') and stream.get('quality_key').lower() == 'uhdbrowser':
+                        if stream.get('is_uhd') and stream.get('quality_key').lower() == 'uhdsmarttv':
                             uhd_video_url = generateDRMVideoUrl(stream.get('src'), drm_lic_url)
                             createListItem("[UHD] %s" % title, banner, description, duration,time.strftime('%Y-%m-%d', livestreamStart), programName, uhd_video_url, True, False, self.defaultbackdrop, self.pluginhandle)
 


### PR DESCRIPTION
Hi, danke für das Plugin.

Das 'UHDBrowser' Manifest hat lediglich 25fps. Das mit 50fps gibts gemäß der ORF Api per 'UHDSmartTV'. Code ist ungetestet, aber sollte funktionieren. Ich bekomme mit deinem Auth-Token auch das 50fps Manifest.

```json
"dash":
[
    {
        "is_uhd": true,
        "quality_key": "UHDANDROIDTV",
        "quality_description": "UHD fuer AndroidTV und FireTV inkl. DRM Schutz",
        "src": "https://orfuhd.mdn.ors.at/orf/orf_uhd_50/drmqxa/manifest.mpd?maxrate=20000000",
        "is_adaptive_stream": true,
        "is_drm_protected": true
    },
    {
        "is_uhd": true,
        "quality_key": "UHDBrowser",
        "quality_description": "UHD fuer Browser mit DRM Schutz",
        "src": "https://orfuhd.mdn.ors.at/orf/orf_uhd_25/drmqxa/manifest.mpd",
        "is_adaptive_stream": true,
        "is_drm_protected": true
    },
    {
        "is_uhd": true,
        "quality_key": "UHDSMARTTV",
        "quality_description": "UHD fuer SmartTV mit DRM Schutz",
        "src": "https://orfuhd.mdn.ors.at/orf/orf_uhd_50/drmqxa/manifest.mpd",
        "is_adaptive_stream": true,
        "is_drm_protected": true
    },
    {
        "is_uhd": false,
        "quality_key": "QXADRM",
        "quality_description": "DRMTestbetrieb",
        "src": "https://orf1.mdn.ors.at/orf/orf1/drmqxa/manifest.mpd?audio=deu",
        "is_adaptive_stream": true,
        "is_drm_protected": true
    },
    {
        "is_uhd": false,
        "quality_key": "QXBDRM",
        "quality_description": "DRMTestbetrieb",
        "src": "https://orf1.mdn.ors.at/orf/orf1/drmqxb/manifest.mpd?audio=deu",
        "is_adaptive_stream": true,
        "is_drm_protected": true
    }
],
```

```bash
↪  yt-dlp --allow-u -F "https://orfuhd.mdn.ors.at/orf/orf_uhd_25/drmqxa/manifest.mpd"
[generic] manifest: Downloading webpage
[generic] manifest: Extracting information
[info] Available formats for manifest:
ID                      EXT RESOLUTION FPS │    TBR PROTO │ VCODEC           VBR ACODEC      ABR ASR MORE INFO
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
audio_165283_deu=164800 m4a audio only     │   165k dash  │ audio only           mp4a.40.2  165k 48k [de] DASH audio, m4a_dash
video=7387600           mp4 1280x720    25 │  7388k dash  │ hvc1.1.6.H153  7388k video only          DASH video, mp4_dash
video=10537600          mp4 1920x1080   25 │ 10538k dash  │ hvc1.1.6.H153 10538k video only          DASH video, mp4_dash
video=16837600          mp4 2560x1440   25 │ 16838k dash  │ hvc1.1.6.H153 16838k video only          DASH video, mp4_dash
video=25237600          mp4 3840x2160   25 │ 25238k dash  │ hvc1.1.6.H153 25238k video only          DASH video, mp4_dash
```

```bash
↪  yt-dlp --allow-u -F "https://orfuhd.mdn.ors.at/orf/orf_uhd_50/drmqxa/manifest.mpd"
[generic] manifest: Downloading webpage
[generic] manifest: Extracting information
[info] Available formats for manifest:
ID                      EXT RESOLUTION FPS │    TBR PROTO │ VCODEC           VBR ACODEC      ABR ASR MORE INFO
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
audio_208482_deu=208000 m4a audio only     │   208k dash  │ audio only           mp4a.40.2  208k 48k [de] DASH audio, m4a_dash
video=7425200           mp4 1280x720    50 │  7425k dash  │ hvc1.1.6.H120  7425k video only          DASH video, mp4_dash
video=10575200          mp4 1920x1080   50 │ 10575k dash  │ hvc1.1.6.H123 10575k video only          DASH video, mp4_dash
video=16875200          mp4 2560x1440   50 │ 16875k dash  │ hvc1.1.6.H150 16875k video only          DASH video, mp4_dash
video=25275200          mp4 3840x2160   50 │ 25275k dash  │ hvc1.1.6.H153 25275k video only          DASH video, mp4_dash
```