### PR TITLE
fix: enable multi-segment playback via JSON-RPC

### DIFF
--- a/resources/lib/kodi.py
+++ b/resources/lib/kodi.py
@@ -137,6 +137,12 @@ class Kodi:
                     play_stream = self.build_stream_url(unquote(track.get_stream().get('url')))
                     playlist.add(play_stream, play_item)
                 self.log("Playing Playlist %s from position %d" % (playlist.size(), playlist.getposition()))
+                setResolvedUrl(self.plugin.handle, False, ListItem(offscreen=True))
+                # In GUI mode the playlist player handles playback automatically (plugin URL
+                # is at position 0, segments at 1..n). In JSON-RPC mode no playlist player
+                # is active, so we start playback explicitly.
+                if playlist.size() == len(tracks):
+                    Player().play(playlist, None, False, 0)
         else:
             self.log("Playing Single Video")
             for track in tracks:

--- a/resources/lib/kodi.py
+++ b/resources/lib/kodi.py
@@ -132,17 +132,18 @@ class Kodi:
                 for track in tracks:
                     self.render(track)
             else:
+                pre_size = playlist.size()
                 for track in tracks:
                     play_item = self.render_video(track)
                     play_stream = self.build_stream_url(unquote(track.get_stream().get('url')))
                     playlist.add(play_stream, play_item)
                 self.log("Playing Playlist %s from position %d" % (playlist.size(), playlist.getposition()))
                 setResolvedUrl(self.plugin.handle, False, ListItem(offscreen=True))
-                # In GUI mode the playlist player handles playback automatically (plugin URL
-                # is at position 0, segments at 1..n). In JSON-RPC mode no playlist player
-                # is active, so we start playback explicitly.
-                if playlist.size() == len(tracks):
-                    Player().play(playlist, None, False, 0)
+                # In GUI mode Kodi adds exactly 1 item (the plugin URL) before running the
+                # plugin, so pre_size == 1. In JSON-RPC mode no item is pre-added, so
+                # pre_size != 1 — start playback explicitly from the first new track.
+                if pre_size != 1:
+                    Player().play(playlist, None, False, pre_size)
         else:
             self.log("Playing Single Video")
             for track in tracks:


### PR DESCRIPTION
## Problem

Multi-segment episodes (e.g. ZIB 2 on ORF TVthek) add all segment URLs to a \`PlayList\` and previously called \`Player().play(playlist)\` directly. This caused intermittent crashes with two concurrent BusyDialogs — one opened by Kodi to resolve the plugin URL, one from \`Player().play()\`.

## Fix

Call \`setResolvedUrl(handle, False)\` first to signal that the plugin URL is not directly playable and close the resolution context cleanly.

In **GUI mode**, the playlist player then handles everything automatically: it skips the unresolvable plugin URL at position 0 and plays the segments — same behaviour as before, no regression.

For **JSON-RPC** (\`Player.Open\` via external control like Kodi remotes or home automation), no playlist player is active after \`setResolvedUrl\` returns, so playback would silently stop. We detect this by recording \`pre_size = playlist.size()\` before adding tracks: in GUI mode Kodi always pre-inserts exactly 1 item (the plugin URL itself), so \`pre_size == 1\`. In JSON-RPC mode no item is pre-added, so \`pre_size != 1\` — we then start playback explicitly from position \`pre_size\` (the first newly added track). This also correctly handles the case where the global playlist has leftover items from a previous session.

## Note

I put this together to fix JSON-RPC control of multi-segment content and it works correctly in both GUI and JSON-RPC testing. Happy to hear if there is a cleaner way to distinguish these two contexts.